### PR TITLE
Professional listing API with filters and validation tests

### DIFF
--- a/app/Http/Controllers/Api/v1/Professional/ProfessionalController.php
+++ b/app/Http/Controllers/Api/v1/Professional/ProfessionalController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1\Professional;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Professional\ProfessionalFilterRequest;
+use App\Models\Professional;
+
+class ProfessionalController extends Controller
+{
+    public function index(ProfessionalFilterRequest $request)
+    {
+        $professional = Professional::when($request->filled('status'), function ($query) use ($request) {
+            $query->where('status', $request->status);
+        })->when($request->filled('order'), function ($query) use ($request) {
+            $query->orderBy('name', $request->order);
+        })->limit(empty($request->count) ? 10 : $request->count)
+            ->offset(empty($request->page) ? 0 : $request->page * 5)
+            ->get(['id', 'name', 'specialty']);
+
+        return response([
+            'status' => true,
+            'message' => "List of Professionals",
+            'data' => $professional
+        ]);
+    }
+}

--- a/app/Http/Requests/Professional/ProfessionalFilterRequest.php
+++ b/app/Http/Requests/Professional/ProfessionalFilterRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Professional;
+
+use App\Http\Requests\BaseApiRequest;
+
+class ProfessionalFilterRequest extends BaseApiRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'order' => 'in:desc,asc',
+            'page'   => 'numeric',
+            'count'   => 'numeric'
+        ];
+    }
+}

--- a/app/Models/Professional.php
+++ b/app/Models/Professional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Professional extends Model
+{
+    use SoftDeletes, HasFactory;
+
+    protected $fillable = [
+        'name',
+        'specialty',
+        'status'
+    ];
+}

--- a/database/factories/ProfessionalFactory.php
+++ b/database/factories/ProfessionalFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Professional>
+ */
+class ProfessionalFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'specialty' => $this->faker->randomElement([
+                'Cardiology',
+                'Neurology',
+                'Orthopedics',
+                'Pediatrics',
+                'Dermatology'
+            ]),
+            'status' => 1
+        ];
+    }
+}

--- a/database/migrations/2025_08_13_103039_create_professionals_table.php
+++ b/database/migrations/2025_08_13_103039_create_professionals_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('professionals', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('specialty');
+            $table->boolean('status')->default(1);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('professionals');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(ProfessionalSeeder::class);
     }
 }

--- a/database/seeders/ProfessionalSeeder.php
+++ b/database/seeders/ProfessionalSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Professional;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ProfessionalSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Professional::truncate();
+        Professional::factory()->count(20)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Http\Controllers\Api\v1\Professional\ProfessionalController;
 use App\Http\Controllers\Api\v1\User\AuthController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
     Route::post('/auth/register', [AuthController::class, 'register']);
     Route::post('/auth/login', [AuthController::class, 'login']);
+    Route::get('/professional/index', [ProfessionalController::class, 'index'])->name('professional.index');
 });

--- a/tests/Feature/ProfessionalTest.php
+++ b/tests/Feature/ProfessionalTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Professional;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProfessionalTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * A basic feature test example.
+     */
+    public function test_professional_list_successully()
+    {
+        Professional::factory()->count(20)->create();
+        $payload = [
+            'order' => 'asc',
+            'page'  => 2,
+            'count' => 10
+        ];
+        $response = $this->getJson(route('professional.index', $payload));
+
+        $response->assertStatus(200)->assertJsonStructure([
+            'status',
+            'message',
+            'data' => [
+                [
+                    'id',
+                    'name',
+                    'specialty'
+                ]
+            ]
+        ]);
+    }
+
+    public function test_professional_list_fails_with_invalid_data()
+    {
+        Professional::factory()->count(20)->create();
+        $payload = [
+            'page' => "number",
+            'order' => "top",
+            'count' => "all"
+        ];
+
+        $response = $this->getJson(route('professional.index', $payload));
+
+        $response->assertStatus(422)->assertJsonStructure([
+            'status',
+            'message',
+            'data'
+        ]);
+    }
+}


### PR DESCRIPTION
### Changes
- Added ProfessionalFactory for test data generation.
- Implemented API endpoint `/api/v1/professional/index`:
  - Filter by `status` (optional)
  - Sort by `name` using `order` param (optional)
  - Support pagination using `limit` and `offset`
- Added request validation to handle invalid parameters.
- Added database seeder for Professional model.
- Added PHPUnit tests for:
  - Successful listing with valid filters
  - Error response with invalid query parameters